### PR TITLE
Precompiled runtime

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -2,29 +2,42 @@
 
 ## Caching of compiled artifacts
 
-`heroku run bash` to app, and then capture the artifacts 
+Requires an S3 bucket with a public-by-default policy:
+
+```json
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowPublicRead",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "*"
+            },
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::kong-on-heroku",
+                "arn:aws:s3:::kong-on-heroku/*"
+            ]
+        }
+    ]
+}
+```
+
+Make sure the templator app has the AWS CLI install:
+
+```bash
+heroku buildpacks:add --index=1 mars/awscli
+git commit --allow-empty -m 'Add AWS CLI buildpack'
+git push heroku master
+```
+
+`heroku run bash` to app, and then capture the artifacts:
 
 ```bash
 ARCHIVE_NAME=kong-runtime-v5.1.1.tgz
 tar czfv $ARCHIVE_NAME ./kong-runtime
-
-file=$ARCHIVE_NAME
-bucket=kong-on-heroku
-s3Key=xxxxx
-s3Secret=yyyyy
-# default regionEndpoint is "s3"
-regionEndpoint=s3-us-west-1
-resource="/${bucket}/${file}"
-contentType="application/x-compressed-tar"
-dateValue=`date -R`
-stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
-signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${s3Secret} -binary | base64`
-curl -X PUT -T "${file}" \
-  -H "Host: ${bucket}.${regionEndpoint}.amazonaws.com" \
-  -H "Date: ${dateValue}" \
-  -H "Content-Type: ${contentType}" \
-  -H "Authorization: AWS ${s3Key}:${signature}" \
-  -H "x-amz-acl: public-read" \
-  https://${bucket}.${regionEndpoint}.amazonaws.com/${file}
-
+aws s3 cp $ARCHIVE_NAME s3://kong-on-heroku/
 ```

--- a/DEV.md
+++ b/DEV.md
@@ -6,25 +6,25 @@
 
 ```bash
 ARCHIVE_NAME=kong-runtime-v5.1.1.tgz
-mv .heroku kong-runtime
 tar czfv $ARCHIVE_NAME ./kong-runtime
 
 file=$ARCHIVE_NAME
 bucket=kong-on-heroku
+s3Key=xxxxx
+s3Secret=yyyyy
 # default regionEndpoint is "s3"
 regionEndpoint=s3-us-west-1
 resource="/${bucket}/${file}"
 contentType="application/x-compressed-tar"
 dateValue=`date -R`
 stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
-s3Key=xxxxx
-s3Secret=yyyyy
 signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${s3Secret} -binary | base64`
 curl -X PUT -T "${file}" \
   -H "Host: ${bucket}.${regionEndpoint}.amazonaws.com" \
   -H "Date: ${dateValue}" \
   -H "Content-Type: ${contentType}" \
   -H "Authorization: AWS ${s3Key}:${signature}" \
+  -H "x-amz-acl: public-read" \
   https://${bucket}.${regionEndpoint}.amazonaws.com/${file}
 
 ```

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,30 @@
+# Buildpack Development
+
+## Caching of compiled artifacts
+
+`heroku run bash` to app, and then capture the artifacts 
+
+```bash
+ARCHIVE_NAME=kong-runtime-v5.1.1.tgz
+mv .heroku kong-runtime
+tar czfv $ARCHIVE_NAME ./kong-runtime
+
+file=$ARCHIVE_NAME
+bucket=kong-on-heroku
+# default regionEndpoint is "s3"
+regionEndpoint=s3-us-west-1
+resource="/${bucket}/${file}"
+contentType="application/x-compressed-tar"
+dateValue=`date -R`
+stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
+s3Key=xxxxx
+s3Secret=yyyyy
+signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${s3Secret} -binary | base64`
+curl -X PUT -T "${file}" \
+  -H "Host: ${bucket}.${regionEndpoint}.amazonaws.com" \
+  -H "Date: ${dateValue}" \
+  -H "Content-Type: ${contentType}" \
+  -H "Authorization: AWS ${s3Key}:${signature}" \
+  https://${bucket}.${regionEndpoint}.amazonaws.com/${file}
+
+```

--- a/DEV.md
+++ b/DEV.md
@@ -1,6 +1,6 @@
 # Buildpack Development
 
-## Caching of compiled artifacts
+## Pre-compiled runtime archive
 
 Requires an S3 bucket with a public-by-default policy:
 
@@ -41,7 +41,8 @@ git push heroku master
 `heroku run bash` to app, and then capture the artifacts:
 
 ```bash
-ARCHIVE_NAME=kong-runtime-v5.1.1.tgz
+BUILDPACK_RELEASE_TAG=v6.0.0
+ARCHIVE_NAME=kong-runtime-$BUILDPACK_RELEASE_TAG.tgz
 tar czfv $ARCHIVE_NAME ./kong-runtime
 aws s3 cp $ARCHIVE_NAME s3://kong-on-heroku/
 ```

--- a/DEV.md
+++ b/DEV.md
@@ -30,6 +30,10 @@ Make sure the templator app has the AWS CLI install:
 
 ```bash
 heroku buildpacks:add --index=1 mars/awscli
+heroku config:set \
+  AWS_ACCESS_KEY_ID=xxxxx \
+  AWS_SECRET_ACCESS_KEY=yyyyy \
+  AWS_DEFAULT_REGION=us-west-1
 git commit --allow-empty -m 'Add AWS CLI buildpack'
 git push heroku master
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -114,7 +114,7 @@ Background
 ----------
 The first time this buildpack builds an app, the build time will be significantly longer as Kong and its dependencies are compiled from source. **The compiled artifacts are cached to speed up subsequent builds.**
 
-We vendor the sources for Lua, LuaRocks, & OpenResty/Nginx and compile them with a writable `/app/.heroku` prefix. Attempts to bootstrap Kong on Heroku using existing [Lua](https://github.com/leafo/heroku-buildpack-lua) & [apt](https://github.com/heroku/heroku-buildpack-apt) buildpacks failed due to their compile-time prefixes of `/usr/local` which is read-only in a dyno.
+We vendor the sources for Lua, LuaRocks, & OpenResty/Nginx and compile them with a writable `/app/kong-runtime` prefix. Attempts to bootstrap Kong on Heroku using existing [Lua](https://github.com/leafo/heroku-buildpack-lua) & [apt](https://github.com/heroku/heroku-buildpack-apt) buildpacks failed due to their compile-time prefixes of `/usr/local` which is read-only in a dyno.
 
 OpenSSL 1.0.2 (required by OpenResty) is also compiled from source.
 

--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,10 @@ Deploy [Kong 0.14 Community Edition](https://konghq.com/kong-community-edition/)
 
 🔬👩‍💻 This software is a community proof-of-concept: [MIT license](LICENSE)
 
+Upgrading
+---------
+
+🚨 **Potentially breaking change** in v6.0.0 to support rapid deployments using a pre-compiled Kong binary. See: [UPGRADING](UPGRADING.md).
 
 Usage
 -----

--- a/README.markdown
+++ b/README.markdown
@@ -5,15 +5,14 @@ Deploy [Kong 0.14 Community Edition](https://konghq.com/kong-community-edition/)
 
 🔬👩‍💻 This software is a community proof-of-concept: [MIT license](LICENSE)
 
-Upgrading
----------
-
-🚨 **Potentially breaking change** in v6.0.0 to support rapid deployments using a pre-compiled Kong binary. See: [UPGRADING](UPGRADING.md).
-
 Usage
 -----
 
 ⏩ **Deploy the [heroku-kong app](https://github.com/heroku/heroku-kong) to get started.**
+
+### Upgrading
+
+Potentially breaking changes are documented in [UPGRADING](UPGRADING.md).
 
 ### Custom
 
@@ -72,6 +71,7 @@ git push heroku master
   * Kong itself may be configured with [`KONG_` prefixed variables](https://docs.konghq.com/0.14.x/configuration/#environment-variables)
   * Heroku build configuration:
     * These variables only effect new deployments.
+    * `KONG_RUNTIME_ARCHIVE_URL` location of [pre-compiled Kong runtime archive](DEV.md#pre-compiled-runtime-archive)
     * ⏱ **Setting these will lengthen build-time, usually 4-8 minutes for compilation from source.** By default, this buildpack downloads pre-compiled, cached Kong binaries to accelerate deployment time. (More details available in [DEV](DEV.md).)
     * `KONG_GIT_URL` git repo URL for Kong source
       * default: `https://github.com/kong/kong.git`

--- a/README.markdown
+++ b/README.markdown
@@ -63,12 +63,16 @@ git push heroku master
 
   * `PORT` exposed on the app/dyno
     * set automatically by the Heroku dyno manager
-  * `KONG_GIT_URL` git repo URL for Kong source
-    * example `https://github.com/Mashape/kong.git`
-  * `KONG_GIT_COMMITISH` git branch/tag/commit for Kong source
-    * example `master`
   * `DATABASE_URL`
     * set automatically by [Heroku Postgres add-on](https://elements.heroku.com/addons/heroku-postgresql)
+  * Kong itself may be configured with [`KONG_` prefixed variables](https://docs.konghq.com/0.14.x/configuration/#environment-variables)
+  * Heroku build configuration:
+    * These variables only effect new deployments.
+    * ⏱ **Setting these will lengthen build-time, usually 4-8 minutes for compilation from source.** By default, this buildpack downloads pre-compiled, cached Kong binaries to accelerate deployment time. (More details available in [DEV](DEV.md).)
+    * `KONG_GIT_URL` git repo URL for Kong source
+      * default: `https://github.com/kong/kong.git`
+    * `KONG_GIT_COMMITISH` git branch/tag/commit for Kong source
+      * default: `master`
 
 
 #### Using Environment Variables in Plugins

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,17 @@
+Upgrading the Kong buildpack for Heroku
+=======================================
+
+[v6.0.0](https://github.com/heroku/heroku-buildpack-kong/releases)
+------
+
+🚨 **Potentially breaking change** to support rapid deployments using a pre-compiled Kong binary.
+
+Kong's filesystem prefix is changing in this buildpack:
+
+> `/app/.heroku` → `/app/kong-runtime`
+
+In your app's `config/kong.conf.etlua` file, change the **prefix** value to `/app/kong-runtime/`, & commit the change.
+
+Search your app for `.heroku` to find any other instances of `/app/.heroku` that may need to be updated to `/app/kong-runtime`.
+
+A backward-compatibility patch is applied automatically, linking `/app/.heroku` to `/app/kong-runtime`. We still advised using the new prefix to avoid any strange behavior from invoking executables through a symbolic link.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,7 +1,8 @@
 Upgrading the Kong buildpack for Heroku
 =======================================
 
-[v6.0.0](https://github.com/heroku/heroku-buildpack-kong/releases)
+
+[v6.0.0](https://github.com/heroku/heroku-buildpack-kong/releases/tag/v6.0.0)
 ------
 
 🚨 **Potentially breaking change** to support rapid deployments using a pre-compiled Kong binary.
@@ -14,4 +15,14 @@ In your app's `config/kong.conf.etlua` file, change the **prefix** value to `/ap
 
 Search your app for `.heroku` to find any other instances of `/app/.heroku` that may need to be updated to `/app/kong-runtime`.
 
-A backward-compatibility patch is applied automatically, linking `/app/.heroku` to `/app/kong-runtime`. We still advised using the new prefix to avoid any strange behavior from invoking executables through a symbolic link.
+⭐️ *A backward-compatibility patch is applied automatically, linking `/app/.heroku` to `/app/kong-runtime`. We still advise using the new prefix to avoid any strange behavior from invoking executables through a symbolic link.*
+
+
+[v5.0.0](https://github.com/heroku/heroku-buildpack-kong/releases/tag/v5.0.0)
+------
+
+🚨 **Potentially breaking change** to upgrade to Kong 0.14 from an earlier version.
+
+We advise recreating your Kong app & its configuration using this newest version.
+
+👓 See [Kong's official upgrade path](https://github.com/Kong/kong/blob/master/UPGRADE.md).

--- a/bin/app/heroku-buildpack-kong-release
+++ b/bin/app/heroku-buildpack-kong-release
@@ -23,22 +23,4 @@ then
   ./bin/prerelease
 fi
 
-echo "~~~~~~~ Debug ~~~~~~~"
-echo "which resty"
-which resty || echo "(none)"
-echo '/usr/bin/env'
-/usr/bin/env
-echo '$PATH'
-echo "$PATH"
-echo "ls -hal /app"
-ls -hal /app || echo "(none)"
-echo "ls -hal /app/.heroku"
-ls -hal /app/.heroku || echo "(none)"
-echo "ls -hal /app/.heroku/bin"
-ls -hal /app/.heroku/bin || echo "(none)"
-echo "ls -hal /app/kong-runtime"
-ls -hal /app/kong-runtime || echo "(none)"
-echo "ls -hal /app/kong-runtime/bin"
-ls -hal /app/kong-runtime/bin || echo "(none)"
-
 kong migrations up -c $KONG_CONF $@

--- a/bin/app/heroku-buildpack-kong-release
+++ b/bin/app/heroku-buildpack-kong-release
@@ -23,4 +23,22 @@ then
   ./bin/prerelease
 fi
 
+echo "~~~~~~~ Debug ~~~~~~~"
+echo "which resty"
+which resty || echo "(none)"
+echo '/usr/bin/env'
+/usr/bin/env
+echo '$PATH'
+echo "$PATH"
+echo "ls -hal /app"
+ls -hal /app || echo "(none)"
+echo "ls -hal /app/.heroku"
+ls -hal /app/.heroku || echo "(none)"
+echo "ls -hal /app/.heroku/bin"
+ls -hal /app/.heroku/bin || echo "(none)"
+echo "ls -hal /app/kong-runtime"
+ls -hal /app/kong-runtime || echo "(none)"
+echo "ls -hal /app/kong-runtime/bin"
+ls -hal /app/kong-runtime/bin || echo "(none)"
+
 kong migrations up -c $KONG_CONF $@

--- a/bin/app/heroku-buildpack-kong-web
+++ b/bin/app/heroku-buildpack-kong-web
@@ -4,7 +4,7 @@ set -eu
 # Customized Nginx setup
 # https://docs.konghq.com/0.14.x/configuration/
 
-APP_PREFIX="${APP_PREFIX:-/app/.heroku}"
+APP_PREFIX="${APP_PREFIX:-/app/kong-runtime}"
 KONG_CONF="${KONG_CONF:-config/kong.conf}"
 NGINX_TEMPLATE="config/nginx.template"
 NGINX_TEMPLATE_PARAM=""

--- a/bin/compile
+++ b/bin/compile
@@ -109,15 +109,15 @@ topic "Writing profile script"
 mkdir -p $BUILD_DIR/.profile.d
 # ~~~~~ Keep these values in sync with the build-time exports below ~~~~~
 cat <<EOF >$BUILD_DIR/.profile.d/000_buildpack_kong.sh
-export PATH="\$HOME/\$KONG_RUNTIME/nginx/sbin:\$HOME/\$KONG_RUNTIME/luajit/bin:\$HOME/\$KONG_RUNTIME/bin:\$HOME/.apt/usr/local/bin:\$HOME/.apt/usr/bin:\$HOME/.apt/usr/sbin:\$PATH"
-export LD_LIBRARY_PATH="\$HOME/\$KONG_RUNTIME/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LD_LIBRARY_PATH"
-export LIBRARY_PATH="\$HOME/\$KONG_RUNTIME/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LIBRARY_PATH"
-export INCLUDE_PATH="\$HOME/\$KONG_RUNTIME/include:\$HOME/.apt/usr/local/include:\$HOME/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include:\$INCLUDE_PATH"
+export PATH="\$HOME/${KONG_RUNTIME}/nginx/sbin:\$HOME/${KONG_RUNTIME}/luajit/bin:\$HOME/${KONG_RUNTIME}/bin:\$HOME/.apt/usr/local/bin:\$HOME/.apt/usr/bin:\$HOME/.apt/usr/sbin:\$PATH"
+export LD_LIBRARY_PATH="\$HOME/${KONG_RUNTIME}/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LD_LIBRARY_PATH"
+export LIBRARY_PATH="\$HOME/${KONG_RUNTIME}/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LIBRARY_PATH"
+export INCLUDE_PATH="\$HOME/${KONG_RUNTIME}/include:\$HOME/.apt/usr/local/include:\$HOME/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include:\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/local/lib/pkgconfig:\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
-export LUA_PATH="\$HOME/lib/?.lua;\$HOME/lib/?/init.lua;\$HOME/.luarocks/share/lua/5.1/?.lua;\$HOME/.luarocks/share/lua/5.1/?/init.lua;\$HOME/\$KONG_RUNTIME/share/lua/5.1/?.lua;\$HOME/\$KONG_RUNTIME/share/lua/5.1/?/init.lua;./?.lua"
-export LUA_CPATH="\$HOME/lib/?.so;\$HOME/.luarocks/lib/lua/5.1/?.so;\$HOME/\$KONG_RUNTIME/lib/lua/5.1/?.so;./?.so"
+export LUA_PATH="\$HOME/lib/?.lua;\$HOME/lib/?/init.lua;\$HOME/.luarocks/share/lua/5.1/?.lua;\$HOME/.luarocks/share/lua/5.1/?/init.lua;\$HOME/${KONG_RUNTIME}/share/lua/5.1/?.lua;\$HOME/${KONG_RUNTIME}/share/lua/5.1/?/init.lua;./?.lua"
+export LUA_CPATH="\$HOME/lib/?.so;\$HOME/.luarocks/lib/lua/5.1/?.so;\$HOME/${KONG_RUNTIME}/lib/lua/5.1/?.so;./?.so"
 EOF
 
 if [ $IS_CUSTOM_BUILD = false ]
@@ -268,6 +268,16 @@ mv config/* $BUILD_DIR/config
 # Move executables for Procfile into place
 mkdir -p $BUILD_DIR/bin
 cp $BP_DIR/bin/app/heroku-* $BUILD_DIR/bin/
+
+topic "Applying buildpack v6.0.0 backward-compatibility patch"
+if [ ! -d ".heroku" ]
+then
+  echo "Linking '/app/.heroku' to '/app/$KONG_RUNTIME'" | indent
+  ln -s "$KONG_RUNTIME/" .heroku
+else
+  echo "'/app/.heroku' exists. Linking skipped." | indent
+  echo "Ensure the app's 'config/kong.conf.etlua' sets the prefix to '/app/$KONG_RUNTIME'" | indent
+fi
 
 # Avoid moving build for CI, because build is in the right place already.
 if [ $IS_CUSTOM_BUILD = true ] && [ ! "$BUILD_DIR" = "/app" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -28,7 +28,7 @@ mkdir -p $BP_CACHE_DIR
 PREFIX_CACHE_DIR=$BP_CACHE_DIR/app_prefix
 
 IS_CUSTOM_BUILD=false
-ARCHIVE_BUILDPACK_VERSION=v5.1.1
+RUNTIME_ARCHIVE_URL="${KONG_RUNTIME_ARCHIVE_URL:-https://s3-us-west-1.amazonaws.com/kong-on-heroku/kong-runtime-v6.0.0.tgz}"
 
 # Source for Kong
 if [ -f "${ENV_DIR}/KONG_GIT_URL" ]
@@ -136,11 +136,8 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 
 if [ $IS_CUSTOM_BUILD = false ]
 then
-  topic "Installing Kong for buildpack ${ARCHIVE_BUILDPACK_VERSION}"
-  cd "${APP_PREFIX}"
-  curl --progress-bar -O "https://s3-us-west-1.amazonaws.com/kong-on-heroku/kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
-  tar  --strip-components=2 -xzf "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
-  rm "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
+  topic "Installing Kong for buildpack from ${RUNTIME_ARCHIVE_URL}"
+  curl --silent --location "${RUNTIME_ARCHIVE_URL}" | tar xzm -C "${APP_PREFIX}" --strip-components=2
 else
 
   # Proceed with build from source

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,8 @@ BP_DIR=`cd $(dirname $0); cd ..; pwd`
 VENDOR_DIR=${BP_DIR}/vendor
 
 # Make dyno runtime-compatible prefix for compiled artifacts
-APP_PREFIX=/app/.heroku
+KONG_RUNTIME=kong-runtime
+APP_PREFIX=/app/$KONG_RUNTIME
 mkdir -p $APP_PREFIX
 
 # Cache compilation artifacts between builds
@@ -26,16 +27,21 @@ BP_CACHE_DIR="$CACHE_DIR/heroku-kong-buildpack"
 mkdir -p $BP_CACHE_DIR
 PREFIX_CACHE_DIR=$BP_CACHE_DIR/app_prefix
 
+IS_CUSTOM_BUILD=false
+ARCHIVE_BUILDPACK_VERSION=v5.1.1
+
 # Source for Kong
 if [ -f "${ENV_DIR}/KONG_GIT_URL" ]
 then
+  IS_CUSTOM_BUILD=true
   KONG_GIT_URL=`cat ${ENV_DIR}/KONG_GIT_URL`
 else
-  KONG_GIT_URL="https://github.com/Mashape/kong.git"
+  KONG_GIT_URL="https://github.com/kong/kong.git"
 fi
 # commit or tag to checkout
 if [ -f "${ENV_DIR}/KONG_GIT_COMMITISH" ]
 then
+  IS_CUSTOM_BUILD=true
   KONG_GIT_COMMITISH=`cat ${ENV_DIR}/KONG_GIT_COMMITISH`
 else
   KONG_GIT_COMMITISH="0.14.1"
@@ -101,139 +107,153 @@ done
 
 topic "Writing profile script"
 mkdir -p $BUILD_DIR/.profile.d
+# ~~~~~ Keep these values in sync with the build-time exports below ~~~~~
 cat <<EOF >$BUILD_DIR/.profile.d/000_buildpack_kong.sh
-export PATH="\$HOME/.heroku/nginx/sbin:\$HOME/.heroku/luajit/bin:\$HOME/.heroku/bin:\$HOME/.apt/usr/local/bin:\$HOME/.apt/usr/bin:\$HOME/.apt/usr/sbin:\$PATH"
-export LD_LIBRARY_PATH="\$HOME/.heroku/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LD_LIBRARY_PATH"
-export LIBRARY_PATH="\$HOME/.heroku/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LIBRARY_PATH"
-export INCLUDE_PATH="\$HOME/.heroku/include:\$HOME/.apt/usr/local/include:\$HOME/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include:\$INCLUDE_PATH"
+export PATH="\$HOME/\$KONG_RUNTIME/nginx/sbin:\$HOME/\$KONG_RUNTIME/luajit/bin:\$HOME/\$KONG_RUNTIME/bin:\$HOME/.apt/usr/local/bin:\$HOME/.apt/usr/bin:\$HOME/.apt/usr/sbin:\$PATH"
+export LD_LIBRARY_PATH="\$HOME/\$KONG_RUNTIME/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LD_LIBRARY_PATH"
+export LIBRARY_PATH="\$HOME/\$KONG_RUNTIME/lib:\$HOME/.apt/usr/lib/x86_64-linux-gnu:\$HOME/.apt/usr/local/lib:\$HOME/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib:\$LIBRARY_PATH"
+export INCLUDE_PATH="\$HOME/\$KONG_RUNTIME/include:\$HOME/.apt/usr/local/include:\$HOME/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include:\$INCLUDE_PATH"
 export CPATH="\$INCLUDE_PATH"
 export CPPPATH="\$INCLUDE_PATH"
 export PKG_CONFIG_PATH="\$HOME/.apt/usr/local/lib/pkgconfig:\$HOME/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:\$HOME/.apt/usr/lib/pkgconfig:\$PKG_CONFIG_PATH"
-export LUA_PATH="\$HOME/lib/?.lua;\$HOME/lib/?/init.lua;\$HOME/.luarocks/share/lua/5.1/?.lua;\$HOME/.luarocks/share/lua/5.1/?/init.lua;\$HOME/.heroku/share/lua/5.1/?.lua;\$HOME/.heroku/share/lua/5.1/?/init.lua;./?.lua"
-export LUA_CPATH="\$HOME/lib/?.so;\$HOME/.luarocks/lib/lua/5.1/?.so;\$HOME/.heroku/lib/lua/5.1/?.so;./?.so"
+export LUA_PATH="\$HOME/lib/?.lua;\$HOME/lib/?/init.lua;\$HOME/.luarocks/share/lua/5.1/?.lua;\$HOME/.luarocks/share/lua/5.1/?/init.lua;\$HOME/\$KONG_RUNTIME/share/lua/5.1/?.lua;\$HOME/\$KONG_RUNTIME/share/lua/5.1/?/init.lua;./?.lua"
+export LUA_CPATH="\$HOME/lib/?.so;\$HOME/.luarocks/lib/lua/5.1/?.so;\$HOME/\$KONG_RUNTIME/lib/lua/5.1/?.so;./?.so"
 EOF
 
-export PATH="$APP_PREFIX/nginx/sbin:$APP_PREFIX/luajit/bin:$APP_PREFIX/bin:$BUILD_DIR/.apt/usr/local/bin:$BUILD_DIR/.apt/usr/bin:$BUILD_DIR/.apt/usr/sbin:/sbin:$PATH"
-export LD_LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
-export LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
-export INCLUDE_PATH="$APP_PREFIX/include:$BUILD_DIR/.apt/usr/local/include:$BUILD_DIR/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include"
-export CPATH="$INCLUDE_PATH"
-export CPPPATH="$INCLUDE_PATH"
-export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/local/lib/pkgconfig:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig"
-export LUA_PATH="$BUILD_DIR/lib/?.lua;$BUILD_DIR/lib/?/init.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?/init.lua;$APP_PREFIX/share/lua/5.1/?.lua;$APP_PREFIX/share/lua/5.1/?/init.lua;./?.lua"
-export LUA_CPATH="$BUILD_DIR/lib/?.so;$BUILD_DIR/.luarocks/lib/lua/5.1/?.so;$APP_PREFIX/lib/lua/5.1/?.so;./?.so"
-
-#give environment to later buildpacks
-export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$BP_DIR/export"
-
-# Once the installed packages are in the PATH, use them.
-
-# Build from source to have dyno-compatible path prefix
-
-# Cache the build
-VENDOR_CACHE_DIR=${BP_CACHE_DIR}/vendor
-mkdir -p ${VENDOR_CACHE_DIR}
-
-# Detect changes in the vendor/ sources
-topic "Detecting changes in vendor/"
-cd ${VENDOR_DIR}
-VENDOR_DIFF=${BP_CACHE_DIR}/.vendor-diff
-VENDOR_HASH=${BP_CACHE_DIR}/.vendor-hash
-VENDOR_HASH_NEW=${VENDOR_HASH}-new
-touch ${VENDOR_DIFF}
-touch ${VENDOR_HASH}
-touch ${VENDOR_HASH_NEW}
-openssl dgst -sha1 * > ${VENDOR_HASH_NEW}
-# `diff` signals differences with exit codes. Don't fail fast.
-set +e
-diff ${VENDOR_HASH} ${VENDOR_HASH_NEW} > ${VENDOR_DIFF}
-DIFF_STATUS=$?
-set -e
-mv -f ${VENDOR_HASH_NEW} ${VENDOR_HASH}
-
-if [ "$DIFF_STATUS" == 0 ] && [ -d "$PREFIX_CACHE_DIR" ]
+if [ $IS_CUSTOM_BUILD = false ]
 then
-  topic "Restoring from cache"
-  cp -R $PREFIX_CACHE_DIR/* $APP_PREFIX/
-
-elif [ "$DIFF_STATUS" == 0 ] || [ "$DIFF_STATUS" == 1 ]
-then
-  topic "Changes detected"
-  IFS=$'\n' 
-  for DIFF_LINE in $(cat "$VENDOR_DIFF"); do
-    echo "       $DIFF_LINE"
-  done
-  unset IFS
-
-  # Clean-up previous cache
-  rm ${VENDOR_DIFF}
-  rm -rf ${VENDOR_CACHE_DIR}
-  # and cache the new source code
-  mv ${VENDOR_DIR} ${VENDOR_CACHE_DIR}
-  cd ${VENDOR_CACHE_DIR}
-
-  topic "Building OpenSSL"
-  openssl_name="openssl-${OPENSSL_VERSION}"
-  mkdir -p "${openssl_name}"
-  tar -xz -f "${openssl_name}.tar.gz" -C "${openssl_name}" --strip-components=1
-  cd "${openssl_name}"
-  ./config --prefix=$APP_PREFIX -fPIC
-  make
-  make install
-  cd ..
-
-  topic "Building OpenResty"
-  tar -xf openresty-${OPENRESTY_VERSION}.tar.gz
-  cd openresty-${OPENRESTY_VERSION}
-  ./configure --prefix=$APP_PREFIX --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-http_v2_module --with-openssl=${VENDOR_CACHE_DIR}/openssl-${OPENSSL_VERSION}
-  make
-  make install
-  cd ..
-
-
-  topic "Building LuaRocks"
-  tar -xf luarocks-${LUAROCKS_VERSION}.tar.gz
-  cd luarocks-${LUAROCKS_VERSION}
-  ./configure --prefix=${APP_PREFIX} --lua-suffix=jit --with-lua=${APP_PREFIX}/luajit --with-lua-include=${APP_PREFIX}/luajit/include/luajit-2.1
-  make build
-  make install
-  cd ..  
-
-
-  topic "Caching build"
-  mkdir -p $PREFIX_CACHE_DIR
-  cp -Rf $APP_PREFIX/* $PREFIX_CACHE_DIR/
-
+  topic "Installing Kong ${KONG_GIT_COMMITISH} from buildpack ${ARCHIVE_BUILDPACK_VERSION}"
+  curl --progress-bar -O "https://kong-on-heroku.s3.amazonaws.com/kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
+  cd $BUILD_DIR
+  tar -xzf "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
 else
-  error "Error detecting cached build: diff exited ${DIFF_STATUS}"
-fi
 
-topic "Building Kong from ${KONG_GIT_URL}#${KONG_GIT_COMMITISH}"
-# Move the unfortunately named `.luarocks` spec file so that it doesn't
-# interfere during CI. We're migrating Kong apps to use `Rockfile` instead.
-if [ -f "$BUILD_DIR/.luarocks" ]; then
-  mv "$BUILD_DIR/.luarocks" "$BUILD_DIR/Rockfile"
+  # Proceed with build from source
+
+  # ~~~~~ Keep these values in sync with the runtime profile script above ~~~~~
+  export PATH="$APP_PREFIX/nginx/sbin:$APP_PREFIX/luajit/bin:$APP_PREFIX/bin:$BUILD_DIR/.apt/usr/local/bin:$BUILD_DIR/.apt/usr/bin:$BUILD_DIR/.apt/usr/sbin:/sbin:$PATH"
+  export LD_LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
+  export LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
+  export INCLUDE_PATH="$APP_PREFIX/include:$BUILD_DIR/.apt/usr/local/include:$BUILD_DIR/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include"
+  export CPATH="$INCLUDE_PATH"
+  export CPPPATH="$INCLUDE_PATH"
+  export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/local/lib/pkgconfig:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig"
+  export LUA_PATH="$BUILD_DIR/lib/?.lua;$BUILD_DIR/lib/?/init.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?/init.lua;$APP_PREFIX/share/lua/5.1/?.lua;$APP_PREFIX/share/lua/5.1/?/init.lua;./?.lua"
+  export LUA_CPATH="$BUILD_DIR/lib/?.so;$BUILD_DIR/.luarocks/lib/lua/5.1/?.so;$APP_PREFIX/lib/lua/5.1/?.so;./?.so"
+
+  #give environment to later buildpacks
+  export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$BP_DIR/export"
+
+  # Once the installed packages are in the PATH, use them.
+
+  # Build from source to have dyno-compatible path prefix
+
+  # Cache the build
+  VENDOR_CACHE_DIR=${BP_CACHE_DIR}/vendor
+  mkdir -p ${VENDOR_CACHE_DIR}
+
+  # Detect changes in the vendor/ sources
+  topic "Detecting changes in vendor/"
+  cd ${VENDOR_DIR}
+  VENDOR_DIFF=${BP_CACHE_DIR}/.vendor-diff
+  VENDOR_HASH=${BP_CACHE_DIR}/.vendor-hash
+  VENDOR_HASH_NEW=${VENDOR_HASH}-new
+  touch ${VENDOR_DIFF}
+  touch ${VENDOR_HASH}
+  touch ${VENDOR_HASH_NEW}
+  openssl dgst -sha1 * > ${VENDOR_HASH_NEW}
+  # `diff` signals differences with exit codes. Don't fail fast.
+  set +e
+  diff ${VENDOR_HASH} ${VENDOR_HASH_NEW} > ${VENDOR_DIFF}
+  DIFF_STATUS=$?
+  set -e
+  mv -f ${VENDOR_HASH_NEW} ${VENDOR_HASH}
+
+  if [ "$DIFF_STATUS" == 0 ] && [ -d "$PREFIX_CACHE_DIR" ]
+  then
+    topic "Restoring from cache"
+    cp -R $PREFIX_CACHE_DIR/* $APP_PREFIX/
+
+  elif [ "$DIFF_STATUS" == 0 ] || [ "$DIFF_STATUS" == 1 ]
+  then
+    topic "Changes detected"
+    IFS=$'\n' 
+    for DIFF_LINE in $(cat "$VENDOR_DIFF"); do
+      echo "       $DIFF_LINE"
+    done
+    unset IFS
+
+    # Clean-up previous cache
+    rm ${VENDOR_DIFF}
+    rm -rf ${VENDOR_CACHE_DIR}
+    # and cache the new source code
+    mv ${VENDOR_DIR} ${VENDOR_CACHE_DIR}
+    cd ${VENDOR_CACHE_DIR}
+
+    topic "Building OpenSSL"
+    openssl_name="openssl-${OPENSSL_VERSION}"
+    mkdir -p "${openssl_name}"
+    tar -xz -f "${openssl_name}.tar.gz" -C "${openssl_name}" --strip-components=1
+    cd "${openssl_name}"
+    ./config --prefix=$APP_PREFIX -fPIC
+    make
+    make install
+    cd ..
+
+    topic "Building OpenResty"
+    tar -xf openresty-${OPENRESTY_VERSION}.tar.gz
+    cd openresty-${OPENRESTY_VERSION}
+    ./configure --prefix=$APP_PREFIX --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-http_v2_module --with-openssl=${VENDOR_CACHE_DIR}/openssl-${OPENSSL_VERSION}
+    make
+    make install
+    cd ..
+
+
+    topic "Building LuaRocks"
+    tar -xf luarocks-${LUAROCKS_VERSION}.tar.gz
+    cd luarocks-${LUAROCKS_VERSION}
+    ./configure --prefix=${APP_PREFIX} --lua-suffix=jit --with-lua=${APP_PREFIX}/luajit --with-lua-include=${APP_PREFIX}/luajit/include/luajit-2.1
+    make build
+    make install
+    cd ..  
+
+
+    topic "Caching build"
+    mkdir -p $PREFIX_CACHE_DIR
+    cp -Rf $APP_PREFIX/* $PREFIX_CACHE_DIR/
+
+  else
+    error "Error detecting cached build: diff exited ${DIFF_STATUS}"
+  fi
+
+  topic "Building Kong from ${KONG_GIT_URL}#${KONG_GIT_COMMITISH}"
+  # Move the unfortunately named `.luarocks` spec file so that it doesn't
+  # interfere during CI. We're migrating Kong apps to use `Rockfile` instead.
+  if [ -f "$BUILD_DIR/.luarocks" ]; then
+    mv "$BUILD_DIR/.luarocks" "$BUILD_DIR/Rockfile"
+  fi
+  # Ensure we don't have Kong from a previous build
+  luarocks remove kong || true
+  if [ -d "$KONG_SOURCE_DIR" ]
+  then
+    cd $KONG_SOURCE_DIR
+    git fetch
+    git fetch --tags
+    git reset --hard $(git rev-list -n 1 $KONG_GIT_COMMITISH)
+  else
+    git clone $KONG_GIT_URL $KONG_SOURCE_DIR
+    cd $KONG_SOURCE_DIR
+    git checkout $KONG_GIT_COMMITISH
+  fi
+  export OPENSSL_DIR=${APP_PREFIX}
+  # Install Kong itself from the cloned git repo
+  luarocks make ./kong-*.rockspec
+  # Install Kong's dependencies via LuaRocks
+  # (`--local` is required for this to do anything)
+  luarocks install --local ./kong-*.rockspec
+  mkdir -p ${APP_PREFIX}/bin
+  mv bin/* ${APP_PREFIX}/bin/
 fi
-# Ensure we don't have Kong from a previous build
-luarocks remove kong || true
-if [ -d "$KONG_SOURCE_DIR" ]
-then
-  cd $KONG_SOURCE_DIR
-  git fetch
-  git fetch --tags
-  git reset --hard $(git rev-list -n 1 $KONG_GIT_COMMITISH)
-else
-  git clone $KONG_GIT_URL $KONG_SOURCE_DIR
-  cd $KONG_SOURCE_DIR
-  git checkout $KONG_GIT_COMMITISH
-fi
-export OPENSSL_DIR=${APP_PREFIX}
-# Install Kong itself from the cloned git repo
-luarocks make ./kong-*.rockspec
-# Install Kong's dependencies via LuaRocks
-# (`--local` is required for this to do anything)
-luarocks install --local ./kong-*.rockspec
-mv bin/* ${APP_PREFIX}/bin/
 
 topic "Installing Lua rocks specified in Rockfile"
 cd ${BUILD_DIR}
@@ -250,7 +270,7 @@ mkdir -p $BUILD_DIR/bin
 cp $BP_DIR/bin/app/heroku-* $BUILD_DIR/bin/
 
 # Avoid moving build for CI, because build is in the right place already.
-if [ ! "$BUILD_DIR" = "/app" ]; then
+if [ $IS_CUSTOM_BUILD = true ] && [ ! "$BUILD_DIR" = "/app" ]; then
   topic "Making build artifacts available to app"
-  mv $APP_PREFIX $BUILD_DIR/.heroku
+  mv $APP_PREFIX $BUILD_DIR/$KONG_RUNTIME
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -122,8 +122,8 @@ EOF
 
 if [ $IS_CUSTOM_BUILD = false ]
 then
-  topic "Installing Kong ${KONG_GIT_COMMITISH} from buildpack ${ARCHIVE_BUILDPACK_VERSION}"
-  curl --progress-bar -O "https://kong-on-heroku.s3.amazonaws.com/kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
+  topic "Installing Kong for buildpack ${ARCHIVE_BUILDPACK_VERSION}"
+  curl --progress-bar -O "https://s3-us-west-1.amazonaws.com/kong-on-heroku/kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
   cd $BUILD_DIR
   tar -xzf "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
 else

--- a/bin/compile
+++ b/bin/compile
@@ -120,32 +120,30 @@ export LUA_PATH="\$HOME/lib/?.lua;\$HOME/lib/?/init.lua;\$HOME/.luarocks/share/l
 export LUA_CPATH="\$HOME/lib/?.so;\$HOME/.luarocks/lib/lua/5.1/?.so;\$HOME/${KONG_RUNTIME}/lib/lua/5.1/?.so;./?.so"
 EOF
 
+# ~~~~~ Keep these values in sync with the runtime profile script above ~~~~~
+export PATH="$APP_PREFIX/nginx/sbin:$APP_PREFIX/luajit/bin:$APP_PREFIX/bin:$BUILD_DIR/.apt/usr/local/bin:$BUILD_DIR/.apt/usr/bin:$BUILD_DIR/.apt/usr/sbin:/sbin:$PATH"
+export LD_LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
+export LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
+export INCLUDE_PATH="$APP_PREFIX/include:$BUILD_DIR/.apt/usr/local/include:$BUILD_DIR/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include"
+export CPATH="$INCLUDE_PATH"
+export CPPPATH="$INCLUDE_PATH"
+export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/local/lib/pkgconfig:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig"
+export LUA_PATH="$BUILD_DIR/lib/?.lua;$BUILD_DIR/lib/?/init.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?/init.lua;$APP_PREFIX/share/lua/5.1/?.lua;$APP_PREFIX/share/lua/5.1/?/init.lua;./?.lua"
+export LUA_CPATH="$BUILD_DIR/lib/?.so;$BUILD_DIR/.luarocks/lib/lua/5.1/?.so;$APP_PREFIX/lib/lua/5.1/?.so;./?.so"
+
+#give environment to later buildpacks
+export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$BP_DIR/export"
+
 if [ $IS_CUSTOM_BUILD = false ]
 then
   topic "Installing Kong for buildpack ${ARCHIVE_BUILDPACK_VERSION}"
+  cd "${APP_PREFIX}"
   curl --progress-bar -O "https://s3-us-west-1.amazonaws.com/kong-on-heroku/kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
-  cd $BUILD_DIR
-  tar -xzf "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
+  tar  --strip-components=2 -xzf "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
+  rm "kong-runtime-${ARCHIVE_BUILDPACK_VERSION}.tgz"
 else
 
   # Proceed with build from source
-
-  # ~~~~~ Keep these values in sync with the runtime profile script above ~~~~~
-  export PATH="$APP_PREFIX/nginx/sbin:$APP_PREFIX/luajit/bin:$APP_PREFIX/bin:$BUILD_DIR/.apt/usr/local/bin:$BUILD_DIR/.apt/usr/bin:$BUILD_DIR/.apt/usr/sbin:/sbin:$PATH"
-  export LD_LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
-  export LIBRARY_PATH="$APP_PREFIX/lib:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu:$BUILD_DIR/.apt/usr/local/lib:$BUILD_DIR/.apt/usr/lib:/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:/usr/lib"
-  export INCLUDE_PATH="$APP_PREFIX/include:$BUILD_DIR/.apt/usr/local/include:$BUILD_DIR/.apt/usr/include:/usr/include/x86_64-linux-gnu:/usr/include"
-  export CPATH="$INCLUDE_PATH"
-  export CPPPATH="$INCLUDE_PATH"
-  export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/local/lib/pkgconfig:$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig"
-  export LUA_PATH="$BUILD_DIR/lib/?.lua;$BUILD_DIR/lib/?/init.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?.lua;$BUILD_DIR/.luarocks/share/lua/5.1/?/init.lua;$APP_PREFIX/share/lua/5.1/?.lua;$APP_PREFIX/share/lua/5.1/?/init.lua;./?.lua"
-  export LUA_CPATH="$BUILD_DIR/lib/?.so;$BUILD_DIR/.luarocks/lib/lua/5.1/?.so;$APP_PREFIX/lib/lua/5.1/?.so;./?.so"
-
-  #give environment to later buildpacks
-  export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$BP_DIR/export"
-
-  # Once the installed packages are in the PATH, use them.
-
   # Build from source to have dyno-compatible path prefix
 
   # Cache the build
@@ -280,7 +278,7 @@ else
 fi
 
 # Avoid moving build for CI, because build is in the right place already.
-if [ $IS_CUSTOM_BUILD = true ] && [ ! "$BUILD_DIR" = "/app" ]; then
+if [ ! "$BUILD_DIR" = "/app" ]; then
   topic "Making build artifacts available to app"
   mv $APP_PREFIX $BUILD_DIR/$KONG_RUNTIME
 fi

--- a/config/kong.conf.etlua.sample
+++ b/config/kong.conf.etlua.sample
@@ -23,7 +23,7 @@
 # GENERAL
 #------------------------------------------------------------------------------
 
-prefix = /app/.heroku/           # Working directory. Equivalent to Nginx's
+prefix = /app/kong-runtime/      # Working directory. Equivalent to Nginx's
                                  # prefix path, containing temporary files
                                  # and logs.
                                  # Each Kong process must have a separate


### PR DESCRIPTION
Drops build time to around a minute by using pre-compiled Kong downloaded from S3. See [DEV notes](https://github.com/heroku/heroku-buildpack-kong/blob/precompiled-runtime/DEV.md) for how that is setup.

🚨 Switches prefix from `/app/.heroku` to `/app/kong-runtime`. Requires a small app change to avoid breakage, but a compatibility patch is automatically provided. See https://github.com/heroku/heroku-kong/pull/23